### PR TITLE
Add checks for existing username in results

### DIFF
--- a/po/template.pot
+++ b/po/template.pot
@@ -928,10 +928,10 @@ msgstr ""
 msgid "No users found"
 msgstr ""
 
-msgid "Please enter a username to submit."
+msgid "Please enter a username to proceed."
 msgstr ""
 
-msgid "Username must be at least 3 characters long."
+msgid "Username is too short."
 msgstr ""
 
 msgid "Leaderboard"
@@ -1157,4 +1157,7 @@ msgid "Only if you summon the gaming gods"
 msgstr ""
 
 msgid "You need a secret handshake first"
+msgstr ""
+
+msgid "Sorry, this login is already taken."
 msgstr ""

--- a/public/quizRenderer.js
+++ b/public/quizRenderer.js
@@ -1,4 +1,5 @@
 /* global uiStrings */
+/* global existingLogins */
 
 var startBtn = document.querySelector(".start-btn"),
   submitBtn = document.querySelector(".submit-btn"),
@@ -17,6 +18,18 @@ let currentQuestion = 0;
 let correct = 0;
 let questionTimeout = null;
 let timerInterval = null;
+
+function isLoginTaken(login) {
+  const lowerLogin = login.toLowerCase();
+  const storedNick = localStorage.getItem("quizNickname");
+
+  if (storedNick && storedNick.toLowerCase() === lowerLogin) {
+    return false;
+  }
+
+  // Otherwise, check if it's already used
+  return existingLogins.includes(lowerLogin);
+}
 
 function updateUsernameValues(value) {
   const usernameInput = document.getElementById("username");
@@ -39,6 +52,15 @@ window.addEventListener("load", () => {
   }
 
   usernameInput.addEventListener("input", () => {
+    // This needs to be checked only before
+    // we initially set local variable
+    if (isLoginTaken(usernameInput.value)) {
+      usernameInput.classList.add("input-error");
+      usernameInput.setAttribute("title", uiStrings.usernameTaken);
+      usernameInput.focus();
+      return;
+    }
+
     localStorage.setItem("quizNickname", usernameInput.value);
     if (usernameTopHidden) usernameTopHidden.value = usernameInput.value;
 
@@ -51,7 +73,7 @@ window.addEventListener("load", () => {
   const topForm = document.querySelector(".submit-form-top");
   if (topForm) {
     topForm.addEventListener("submit", (event) => {
-      if (!confirm("Are you sure you want to submit?")) {
+      if (!confirm(uiStrings.confirmSubmit)) {
         event.preventDefault();
         return;
       }
@@ -95,19 +117,13 @@ window.addEventListener("load", () => {
 
       if (username === "") {
         usernameInput.classList.add("input-error");
-        usernameInput.setAttribute(
-          "title",
-          "Please enter a username to submit.",
-        );
+        usernameInput.setAttribute("title", uiStrings.usernamePrompt);
         usernameInput.focus();
         return; // Stop if username is missing
       }
-      if (username.length < 3) {
+      if (username.length < 4) {
         usernameInput.classList.add("input-error");
-        usernameInput.setAttribute(
-          "title",
-          "Username must be at least 3 characters long.",
-        );
+        usernameInput.setAttribute("title", uiStrings.tooSimpleUsername);
         usernameInput.focus();
         return; // Stop if username is too short
       }
@@ -148,15 +164,13 @@ function handleStartAction() {
 
   const username = usernameInput.value.trim();
   if (username !== "") {
-    if (username.length < 3) {
+    if (username.length < 4) {
       usernameInput.classList.add("input-error");
-      usernameInput.setAttribute(
-        "title",
-        "Username must be at least 3 characters long.",
-      );
+      usernameInput.setAttribute("title", uiStrings.tooSimpleUsername);
       usernameInput.focus();
       return;
     }
+
     usernameInput.disabled = true;
     document.getElementById("username-top-hidden").value = usernameInput.value;
     usernameInput.classList.remove("input-error");

--- a/src/i18nHelpers.js
+++ b/src/i18nHelpers.js
@@ -34,9 +34,11 @@ function getUiStrings(_, name = "Anonymous") {
     final: _("Final"),
     restart: _("Restart"),
     question: _("Question"),
-    usernamePrompt: _("Please enter a username to start."),
+    usernamePrompt: _("Please enter a username to proceed."),
     welcome: _("Welcome, %s").replace("%s", name),
     confirmSubmit: _("Are you sure you want to quit and submit?"),
+    tooSimpleUsername: _("Username is too short."),
+    usernameTaken: _("Sorry, this login is already taken."),
     confirmQuit: _(
       "Are you sure you want to quit? Your progress will not be saved.",
     ),

--- a/src/route.js
+++ b/src/route.js
@@ -49,8 +49,10 @@ module.exports = (dependencies) => {
 
     const { quizData, questions } = require(quizPath);
     const localized = localizeQuizData({ quizData, questions }, _);
-
     const uiStrings = getUiStrings(_, name);
+    const existingLoginsLower = Object.keys(results || {}).map((k) =>
+      k.toLowerCase(),
+    );
 
     res.render("quiz", {
       nickname: name,
@@ -60,6 +62,7 @@ module.exports = (dependencies) => {
       questions: JSON.stringify(localized.questions),
       uiStrings: uiStrings,
       quizTitle: localized.quizData.title,
+      existingLogins: JSON.stringify(existingLoginsLower),
     });
   });
 

--- a/views/quiz.ejs
+++ b/views/quiz.ejs
@@ -57,10 +57,12 @@
       const nickname = "<%= nickname %>";
       const quizData = <%- quizData %>;
       const questions = <%- questions %>;
+      const existingLogins = <%- existingLogins %>;
       // If we pass it via route without stringify
       // then we can still reference uiStrings.variable in server-rendered HTML
       // stringify is still required for javascript references
       const uiStrings = <%- JSON.stringify(uiStrings) %>;
+
     </script>
     <script src="./quizRenderer.js"></script>
   </body>


### PR DESCRIPTION
* Do not allow to use the nick if it's already in results.
   The only exception is if we previously set it to a local storage which means nick wasn't in results at that time and we're likely the first owner of nick.

* We only add nick to results at the end of the quiz so race condition might still happen.
   We could perhaps store empty results for given nick into result before proceeding taking the /quiz?

[Screencast from 2025-06-05 15-41-03.webm](https://github.com/user-attachments/assets/05bc1646-26fe-41fb-b9d0-b5afb8478914)
