### PR TITLE
Hide should be always set with important

### DIFF
--- a/public/less/styles.less
+++ b/public/less/styles.less
@@ -454,7 +454,7 @@ input[type="text"]:disabled {
 }
 
 .hide {
-  display: none;
+  display: none !important;
 }
 
 .correct {


### PR DESCRIPTION
Actually fixes cases where statusContainer's block overriden our hide

![image](https://github.com/user-attachments/assets/3db0fb7c-a8bd-4feb-aa44-7ef86783d8fb)
