### PR TITLE
Improve default stats file path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 /public/styles.css
 public/stats.json
 netlify/functions/tmp/stats.json
+data/stats.json

--- a/src/consts.js
+++ b/src/consts.js
@@ -16,16 +16,9 @@ const envFileExists = fs.existsSync(envPath);
 // STATS_MODE defaults to "STATS_FILE" if not set in .env or if .env doesn't exist.
 const STATS_MODE = process.env.STATS_MODE || "STATS_FILE";
 
-let resolvedStatsFilePath;
-if (!envFileExists) {
-  // If .env does not exist, use /tmp/stats.json and STATS_MODE is already "STATS_FILE" by default
-  resolvedStatsFilePath = "/tmp/stats.json";
-} else {
-  // If .env exists, use STATS_FILE_PATH from .env or the original default path
-  resolvedStatsFilePath =
-    process.env.STATS_FILE_PATH ||
-    path.join(__dirname, "..", "data", "stats.json");
-}
+// prefer STATS_FILE_PATH from environment and fall back to file inside repository root
+let resolvedStatsFilePath =
+  process.env.STATS_FILE_PATH || path.join(projectRoot, "data", "stats.json");
 const STATS_FILE_PATH = resolvedStatsFilePath;
 
 // RESET_TOKEN defaults to "supersecret" if not set in .env or if .env doesn't exist.


### PR DESCRIPTION
1. no longer default to insecure /tmp
2. set to value of STATS_FILE_PATH if defined
3. set alternative to path which is already used in docker build

https://github.com/openSUSE/quiz/issues/111