### PR TITLE
Add instances configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 # the repo. They will be requested for review when someone
 # opens a pull request.
 *   @lkocman @onuralpszr
+
+/instances.json @tacerus

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,6 @@ public/stats.json.sample
 package.json
 package-lock.json
 bun.lock
+
+# we want trailing commas in json5 for easier diff-ing
+instances.json

--- a/instances.json
+++ b/instances.json
@@ -1,0 +1,9 @@
+// vim:filetype=json5
+{
+  "instances": {
+    // "main" maps to quiz.opesuse.org
+    "main": {},
+    // all others map to <instance>.quiz.opensuse.org
+    "test": {},
+  }
+}


### PR DESCRIPTION
This will be read by deploy-quizzes.py to manage deployments in the openSUSE infrastructure. New entries will trigger the creation of an instance, removed entries will trigger the removal of an instance. The instances are listed as objects instead of array elements to allow for future addition of instance specific configuration options, such as the enabled question catalogues.