### PR TITLE
Be able to specify username policy

### DIFF
--- a/po/extract-pot.sh
+++ b/po/extract-pot.sh
@@ -19,7 +19,7 @@ fi
 : > "$TEMP_GENERATED_POT" # Was MASTER_POT
 
 # Loop over all relevant JS source files
-for jsfile in "$DATA_DIR"/*.js "$SRC_DIR"/i18nHelpers.js; do
+for jsfile in "$DATA_DIR"/*.js "$SRC_DIR"/i18nHelpers.js "$SRC_DIR"/consts.js; do
     name=$(basename "${jsfile%.js}") # Strip .js suffix
     potfile="$OUT_DIR/$name.pot"
 

--- a/po/template.pot
+++ b/po/template.pot
@@ -1226,3 +1226,6 @@ msgstr ""
 
 msgid "Are you sure you want to quit? Your progress will not be saved."
 msgstr ""
+
+msgid "Use a recognizable nickname, like ZypperJedi, or preferably your real name (NameSurname)."
+msgstr ""

--- a/public/quizRenderer.js
+++ b/public/quizRenderer.js
@@ -202,7 +202,9 @@ nextBtn.addEventListener("click", () => {
 
 function startQuiz() {
   const usernameForm = document.querySelector(".submit-form-bottom");
+  const usernameInstructions = document.querySelector(".username-instructions");
   usernameForm.classList.add("hide");
+  usernameInstructions.classList.add("hide");
 
   nextBtn.classList.remove("hide");
   questionContainer.classList.remove("hide");

--- a/src/consts.js
+++ b/src/consts.js
@@ -28,6 +28,14 @@ const RESET_TOKEN = envFileExists
 
 const EVENT = process.env.EVENT || "openSUSE";
 
+// Just a helper function to detect _() by gettext
+function _(str) {
+  return str;
+}
+const USERNAME_POLICY =
+  process.env.USERNAME_POLICY ||
+  _("Use a recognizable nickname, like ZypperJedi, or preferably your real name (NameSurname).");
+
 module.exports = {
   DATA_DIR_BASEPATH,
   DATA_DIR_PATH,
@@ -35,4 +43,5 @@ module.exports = {
   STATS_MODE,
   STATS_FILE_PATH,
   EVENT,
+  USERNAME_POLICY,
 };

--- a/src/consts.js
+++ b/src/consts.js
@@ -34,7 +34,9 @@ function _(str) {
 }
 const USERNAME_POLICY =
   process.env.USERNAME_POLICY ||
-  _("Use a recognizable nickname, like ZypperJedi, or preferably your real name (NameSurname).");
+  _(
+    "Use a recognizable nickname, like ZypperJedi, or preferably your real name (NameSurname)."
+  );
 
 module.exports = {
   DATA_DIR_BASEPATH,

--- a/src/route.js
+++ b/src/route.js
@@ -60,6 +60,7 @@ module.exports = (dependencies) => {
       lang,
       availableLanguages,
       event: consts.EVENT,
+      usernamePolicy: consts.USERNAME_POLICY,
       quizData: JSON.stringify(localized.quizData),
       questions: JSON.stringify(localized.questions),
       uiStrings: uiStrings,

--- a/views/quiz.ejs
+++ b/views/quiz.ejs
@@ -29,7 +29,9 @@
           <p id="timer" class="hide">⏱️ <%= uiStrings.timeLeft %>: 0</p>
           <p class="correct-count hide">Correct:</p>
         </div>
+        <p class="username-instructions">🙏 <%= usernamePolicy %></p>
       </div>
+
       <div class="question-container hide">
         <p class="question"><%- uiStrings.question %></p>
       </div>


### PR DESCRIPTION
* Per ask of MiguelP
* Allows you to say use your corpo login (or email).
* Default should be translatable, funny and useful.

preview of
`USERNAME_POLICY="Please use your SUSE username to participate." EVENT="BCL Newsletter" npm start`


![image](https://github.com/user-attachments/assets/93e1f7b5-b494-4a14-b55c-c733e0d9f6d1)


