### PR TITLE
Drop openSSL instance add SUSE instance

### DIFF
--- a/instances.json
+++ b/instances.json
@@ -6,6 +6,6 @@
     // all others map to <instance>.quiz.opensuse.org
     "test": {},
     "linuxdays": {},
-    "openssl": {},
+    "suse": {},
   }
 }


### PR DESCRIPTION
* SUSE instance can be used by SUSE booth at both LinuxDays and openSSL

* openSUSE folks will use linuxdays instance on LinuxDays. There is no openSUSE booth at openSSL conf